### PR TITLE
Experimental Coreaudio Support on OS X.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/TPCircularBuffer"]
+	path = src/TPCircularBuffer
+	url = git@github.com:michaeltyson/TPCircularBuffer.git

--- a/Makefile.am
+++ b/Makefile.am
@@ -51,11 +51,13 @@ lib_LTLIBRARIES += src/libpcaudio.la
 src_libpcaudio_la_LDFLAGS = -version-info $(LIBPCAUDIO_VERSION) \
 	${ALSA_LIBS} \
 	${PULSEAUDIO_LIBS} \
-	${QSA_LIBS}
+	${QSA_LIBS} \
+	${COREAUDIO_LIBS}
 
 src_libpcaudio_la_CFLAGS = ${AM_CFLAGS} \
 	${ALSA_CFLAGS} \
-	${PULSEAUDIO_CFLAGS}
+	${PULSEAUDIO_CFLAGS} \
+	${COREAUDIO_CFLAGS}
 
 src_libpcaudio_la_SOURCES = \
 	src/alsa.c \
@@ -63,3 +65,10 @@ src_libpcaudio_la_SOURCES = \
 	src/oss.c \
 	src/pulseaudio.c \
 	src/audio.c
+
+if HAVE_COREAUDIO
+src_libpcaudio_la_SOURCES += \
+	src/coreaudio.c \
+	src/TPCircularBuffer/TPCircularBuffer.c \
+	src/TPCircularBuffer/TPCircularBuffer+AudioBufferList.c
+endif

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ devices. It supports:
 | Audio Framework | Operating System |
 |-----------------|------------------|
 | ALSA            | Linux            |
+| Coreaudio       | Mac OS           |
 | OSS             | POSIX            |
 | PulseAudio      | Linux            |
 | QSA             | QNX              |
@@ -53,6 +54,21 @@ Optional Libraries:
 |----------------|--------------------------------------------|
 | alsa           | `sudo apt-get install libasound2-dev`      |
 | pulseaudio     | `sudo apt-get install libpulse-dev`        |
+
+## Mac OS
+
+To enable Coreaudio output support you need to have the coreaudio framework on your system. Installing XCode along with the Mac OS SDK is the reccomended way of getting it.
+
+To compile Coreaudio support you will also need the TPCircularBuffer external implementation which is bundle  as a git submodule. To get it do:
+
+
+```bash
+
+git submodule init
+git submodule update
+```
+
+
 
 ## Building
 

--- a/configure.ac
+++ b/configure.ac
@@ -8,6 +8,7 @@ AM_SILENT_RULES([yes])
 AC_CONFIG_SRCDIR([src])
 AC_CONFIG_MACRO_DIR([m4])
 AC_CONFIG_HEADERS([config.h])
+AC_CANONICAL_HOST
 
 dnl ================================================================
 dnl Program checks.
@@ -91,6 +92,32 @@ fi
 
 AC_SUBST(QSA_LIBS)
 
+
+dnl ================================================================
+dnl coreaudio checks.
+dnl ================================================================
+
+AC_ARG_WITH([coreaudio],
+    [AS_HELP_STRING([--with-coreaudio], [support for coreaudio audio output on Mac OS @<:@default=yes@:>@])],
+    [])
+
+if test "$with_coreaudio" = "no";then
+    echo "Disabling coreaudio audio output support"
+    have_coreaudio=no
+else
+    if test "${host_os}"="darwin";then
+        COREAUDIO_CFLAGS=-dynamiclib -fvisibility=default
+        COREAUDIO_LIBS="-framework CoreAudio -framework AudioToolbox -framework AudioUnit"
+        have_coreaudio=yes
+        AC_DEFINE(HAVE_COREAUDIO_H, [], [Do we have coreaudio?])
+    else
+        have_coreaudio=no
+    fi
+fi
+
+AC_SUBST(COREAUDIO_CFLAGS)
+AC_SUBST(COREAUDIO_LIBS)
+AM_CONDITIONAL([HAVE_COREAUDIO], [test "x${have_coreaudio}" = "xyes"])
 dnl ================================================================
 dnl OSS checks.
 dnl ================================================================
@@ -140,5 +167,6 @@ AC_MSG_NOTICE([
 	PulseAudio support:            ${have_pulseaudio}
 	ALSA support:                  ${have_alsa}
 	QSA support:                   ${have_qsa}
+	Coreaudio support:             ${have_coreaudio} 
 	OSS support:                   ${have_oss}
 ])

--- a/src/audio.c
+++ b/src/audio.c
@@ -91,6 +91,11 @@ create_audio_device_object(const char *device,
 	if ((object = create_xaudio2_object(device, application_name, description)) != NULL)
 		return object;
 #else
+#if defined(__APPLE__)
+	if ((object = create_coreaudio_object(device, application_name, description)) != NULL)
+		return object;
+
+#else
 	if ((object = create_pulseaudio_object(device, application_name, description)) != NULL)
 		return object;
 	if ((object = create_alsa_object(device, application_name, description)) != NULL)
@@ -99,6 +104,7 @@ create_audio_device_object(const char *device,
 		return object;
 	if ((object = create_oss_object(device, application_name, description)) != NULL)
 		return object;
+#endif
 #endif
 	return NULL;
 }

--- a/src/audio_priv.h
+++ b/src/audio_priv.h
@@ -81,6 +81,13 @@ create_xaudio2_object(const char *device,
 #define container_of(ptr, type, member) ({                      \
         const typeof( ((type *)0)->member ) *__mptr = (ptr);    \
         (type *)( (char *)__mptr - offsetof(type,member) );})
+#ifdef __APPLE__
+struct audio_object *
+create_coreaudio_object(const char *device,
+						const char *application_name,
+						const char *description);
+
+#else
 
 struct audio_object *
 create_pulseaudio_object(const char *device,
@@ -101,7 +108,7 @@ struct audio_object *
 create_oss_object(const char *device,
                   const char *application_name,
                   const char *description);
-
+#endif
 #endif
 
 #ifdef __cplusplus

--- a/src/coreaudio.c
+++ b/src/coreaudio.c
@@ -1,0 +1,303 @@
+/* Coreaudio Output.
+ *
+ * Copyright (C) 2016 Rui Batista
+ *
+ * This file is part of pcaudiolib.
+ *
+ * pcaudiolib is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * pcaudiolib is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with pcaudiolib.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include "config.h"
+#include "audio_priv.h"
+
+#ifdef HAVE_COREAUDIO_H
+#include <AudioToolbox/AudioToolbox.h>
+#include <CoreServices/CoreServices.h>
+#include "TPCircularBuffer/TPCircularBuffer+AudioBufferList.h"
+#include <string.h>
+#include <stdbool.h>
+#include <errno.h>
+#include <unistd.h>
+
+
+#define min(a,b) ((a) < (b) ? (a):(b))
+
+#define COREAUDIO_BUFFER_SIZE (1024 * 64) // 4m
+
+
+struct coreaudio_object
+{
+	struct audio_object vtable;
+	AudioStreamBasicDescription format;
+	AudioUnit outputUnit;
+	TPCircularBuffer circularBuffer;
+	bool initialized;
+	bool running;
+
+	char *device;
+	char *application_name;
+	char *description;
+};
+
+#define to_coreaudio_object(object) container_of(object, struct coreaudio_object, vtable)
+
+static OSStatus graphRenderProc(void *inRefCon,
+						 AudioUnitRenderActionFlags *ioActionFlags,
+						 const AudioTimeStamp *inTimeStamp,
+						 UInt32 inBusNumber,
+						 UInt32 inNumberFrames,
+						 AudioBufferList * ioData) {
+	struct coreaudio_object *self = (struct coreaudio_object *)inRefCon;
+	if(! self->running){
+		// fill the buffer with sielence, stop was not acnoledged yet
+		memset(ioData->mBuffers[0].mData,0,(self->format).mBytesPerFrame * inNumberFrames);
+		ioData->mBuffers[0].mNumberChannels = 1;
+		ioData->mBuffers[0].mDataByteSize = (self->format).mBytesPerFrame * inNumberFrames;
+		return noErr;
+ }
+	
+	UInt32 available = TPCircularBufferPeek(&(self->circularBuffer), NULL, &(self->format));
+	if(available == 0) {
+		self->running = FALSE;
+		AudioOutputUnitStop(self->outputUnit);
+	}
+	// copy as much data as we can from the circular buffer
+	TPCircularBufferDequeueBufferListFrames(&(self->circularBuffer), &inNumberFrames, ioData, NULL, &(self->format));
+	return noErr;
+}
+
+int
+coreaudio_object_open(struct audio_object *object,
+                       enum audio_object_format format,
+                       uint32_t rate,
+                       uint8_t channels)
+{
+	struct coreaudio_object *self = to_coreaudio_object(object);
+	OSStatus err = noErr;
+	if (self->initialized)
+		return noErr;
+
+	memset(&(self->format), 0, sizeof(AudioStreamBasicDescription));
+	(self->format).mSampleRate = rate;
+	(self->format).mChannelsPerFrame = channels;
+	(self->format).mFramesPerPacket = 1;
+	switch (format)
+	{
+		case AUDIO_OBJECT_FORMAT_S16LE:
+			(self->format).mFormatID = kAudioFormatLinearPCM;
+			(self->format).mBitsPerChannel = 16;
+			(self->format).mFormatFlags = kAudioFormatFlagIsSignedInteger | kAudioFormatFlagsNativeEndian | kAudioFormatFlagIsPacked;
+			break;
+		default:
+			return -1;
+	}
+	// guess the remaining of the AudioBasicStreamDescription structure
+	UInt32 procSize = sizeof(AudioStreamBasicDescription);
+	err = AudioFormatGetProperty(kAudioFormatProperty_FormatInfo, 0, NULL, &procSize, &(self->format));
+	if(err != noErr) {
+		goto cleanup;
+	}
+
+
+	// Find default output
+	AudioComponentDescription outputcd = {0,};
+	outputcd.componentType = kAudioUnitType_Output;
+	outputcd.componentSubType = kAudioUnitSubType_DefaultOutput;
+	outputcd.componentManufacturer = kAudioUnitManufacturer_Apple;
+	
+	// Create a component
+	AudioComponent outputComponent = AudioComponentFindNext(NULL, &outputcd);
+	err = AudioComponentInstanceNew(outputComponent, &(self->outputUnit));
+	if(err != noErr) {
+		goto cleanup;
+	}
+
+	// set render callback
+	AURenderCallbackStruct callbackStruct;
+	callbackStruct.inputProcRefCon = self;
+	callbackStruct.inputProc = graphRenderProc;
+	size_t propSize = sizeof(AURenderCallbackStruct);
+	err = AudioUnitSetProperty(self->outputUnit, kAudioUnitProperty_SetRenderCallback, kAudioUnitScope_Output, 0, &callbackStruct, propSize);
+	if(err != noErr) {
+		goto cleanup;
+	}
+	
+	// set output unit input format
+	propSize = sizeof(AudioStreamBasicDescription);
+	err = AudioUnitSetProperty(self->outputUnit, kAudioUnitProperty_StreamFormat, kAudioUnitScope_Input, 0, &(self->format), propSize);
+	if(err != noErr) {
+		goto cleanup;
+	}
+
+	err = AudioUnitInitialize(self->outputUnit);
+	if(err != noErr) {
+		goto cleanup;
+	}
+	// create a circular buffer to produce and consume audio
+	TPCircularBufferInit(&(self->circularBuffer), COREAUDIO_BUFFER_SIZE);
+
+	self->initialized = TRUE;
+	return noErr;
+cleanup:
+	if(self->outputUnit) {
+		AudioUnitUninitialize(self->outputUnit);
+		AudioComponentInstanceDispose(self->outputUnit);
+	}
+	return err;
+}
+
+void
+coreaudio_object_close(struct audio_object *object)
+{
+	struct coreaudio_object *self = to_coreaudio_object(object);
+	if(self->initialized) {
+		AudioUnitUninitialize(self->outputUnit);
+		AudioComponentInstanceDispose(self->outputUnit);
+		TPCircularBufferCleanup(&(self->circularBuffer));
+		self->initialized = FALSE;
+	}
+
+}
+
+void
+coreaudio_object_destroy(struct audio_object *object)
+{
+	struct coreaudio_object *self = to_coreaudio_object(object);
+
+}
+
+int
+coreaudio_object_drain(struct audio_object *object)
+{
+	struct coreaudio_object *self = to_coreaudio_object(object);
+	if (!self->initialized)
+		return noErr;
+	while(self->running)
+		usleep(10000);
+	return noErr;
+}
+
+int
+coreaudio_object_flush(struct audio_object *object)
+{
+	struct coreaudio_object *self = to_coreaudio_object(object);
+	if (!self->initialized)
+		return noErr;
+
+	OSStatus err = AudioOutputUnitStop(self->outputUnit);
+
+	TPCircularBufferClear(&(self->circularBuffer));
+	self->running = FALSE;
+
+	return err;
+}
+
+int
+coreaudio_object_write(struct audio_object *object,
+                        const void *data,
+                        size_t bytes)
+{
+	struct coreaudio_object *self = to_coreaudio_object(object);
+	if (!self->initialized)
+		return noErr;
+	bool runningAtStart = self->running;
+	if(!runningAtStart) {
+		TPCircularBufferClear(&(self->circularBuffer));
+	}
+	char *dataPtr = (char*)data;
+
+	// copy data to our circular buffer
+	// Poll while we don't have space in the buffer.
+	AudioBufferList *bufferList;
+	UInt32 available;
+	while(bytes > 0) {
+		while((!runningAtStart || self->running) && (available = TPCircularBufferGetAvailableSpace(&(self->circularBuffer), &(self->format))) == 0)
+			usleep(10000);
+
+		// check we didn't stop
+		if(runningAtStart &&  (!self->running))
+			return noErr;
+
+		bufferList = TPCircularBufferPrepareEmptyAudioBufferListWithAudioFormat(&(self->circularBuffer), &(self->format), available, NULL);
+
+		// we are writing mono/interleaved data so we have one buffer
+		UInt32 bytesToWrite = min(bytes, bufferList->mBuffers[0].mDataByteSize);
+		bufferList->mBuffers[0].mNumberChannels = (self->format).mChannelsPerFrame;
+		bufferList->mBuffers[0].mDataByteSize = bytesToWrite;
+		memcpy(bufferList->mBuffers[0].mData, dataPtr, bytesToWrite);
+		TPCircularBufferProduceAudioBufferList(&(self->circularBuffer), NULL);
+		dataPtr += bytesToWrite;
+		bytes -= bytesToWrite;
+		if(! runningAtStart) {
+			OSStatus err = AudioOutputUnitStart(self->outputUnit);
+			if(err == noErr) {
+			self->running = TRUE;
+			runningAtStart = TRUE;
+		} else {
+			return err;
+		}
+	}
+	}
+	return noErr;
+}
+
+const char *
+coreaudio_object_strerror(struct audio_object *object,
+                           int error)
+{
+	return GetMacOSStatusCommentString(error);
+}
+
+static bool
+coreaudio_is_available(const char *device,
+                        const char *application_name,
+                        const char *description)
+{
+	return true;
+}
+
+struct audio_object *
+create_coreaudio_object(const char *device,
+                         const char *application_name,
+                         const char *description)
+{
+	if (!coreaudio_is_available(device, application_name, description))
+		return NULL;
+
+	struct coreaudio_object *self = malloc(sizeof(struct coreaudio_object));
+	if (!self)
+		return NULL;
+
+	self->vtable.open = coreaudio_object_open;
+	self->vtable.close = coreaudio_object_close;
+	self->vtable.destroy = coreaudio_object_destroy;
+	self->vtable.write = coreaudio_object_write;
+	self->vtable.drain = coreaudio_object_drain;
+	self->vtable.flush = coreaudio_object_flush;
+	self->vtable.strerror = coreaudio_object_strerror;
+
+	return &self->vtable;
+}
+
+#else
+
+struct audio_object *
+create_coreaudio_object(const char *device,
+                         const char *application_name,
+                         const char *description)
+{
+	return NULL;
+}
+
+#endif


### PR DESCRIPTION
Limitations:
- Only works with the default audio device
- Probably unstable (needs testing), although I've been using it daily to run espeak-ng along with emacspeak and a patched emacspeak espeak server